### PR TITLE
[code-simplifier] Code Simplification — 2026-03-05

### DIFF
--- a/CareMetrics.Tests/UnitTest1.cs
+++ b/CareMetrics.Tests/UnitTest1.cs
@@ -36,7 +36,7 @@ public class VektisDataServiceTests : IClassFixture<VektisServiceFixture>
 
         Assert.NotEmpty(municipalities);
         Assert.Equal(municipalities.Distinct().Count(), municipalities.Count);
-        Assert.Equal(municipalities.OrderBy(x => x).ToList(), municipalities.ToList());
+        Assert.Equal(municipalities.Order().ToList(), municipalities.ToList());
         Assert.Contains("Amsterdam", municipalities);
     }
 
@@ -125,9 +125,7 @@ public class VektisDataServiceTests : IClassFixture<VektisServiceFixture>
 
         Assert.Equal(n, result.Count);
         Assert.All(result, h => Assert.True(h.Rank > 0));
-        // ranks are sequential 1..n
-        for (int i = 0; i < result.Count; i++)
-            Assert.Equal(i + 1, result[i].Rank);
+        Assert.Equal(Enumerable.Range(1, result.Count), result.Select(h => h.Rank));
     }
 
     // ── CompareRegions ────────────────────────────────────────────────


### PR DESCRIPTION
This PR simplifies recently modified C# code to improve clarity, consistency, and maintainability while preserving all functionality.

### Files Simplified

- `CareMetrics.Tests/UnitTest1.cs` — Applied C# 11+ idioms to test assertions

### Improvements Made

1. **Applied Modern C# Idiom** (`GetMunicipalities_ReturnsDistinctSortedValues`)
   - Replaced `OrderBy(x => x)` with `Order()` — the idiomatic C# 11+ shorthand for ascending sort with no explicit key selector

2. **Replaced Imperative Loop with Declarative Assertion** (`GetHotspots_ValidInputs_ReturnsCorrectCount`)
   - Replaced a `for` loop with `Assert.Equal(Enumerable.Range(1, result.Count), result.Select(h => h.Rank))`
   - The LINQ expression more clearly communicates intent: ranks must be sequential integers starting at 1

### Changes Based On

Recent changes from:
- #23 — Replace empty UnitTest1.cs placeholder with meaningful VektisDataService test coverage

### Testing

- ✅ Formatting verified manually (no style changes beyond the simplifications)
- ✅ No functional changes — behaviour is identical; assertions are semantically equivalent
- ⚠️ `dotnet test` could not be run locally due to network restrictions in this sandbox — CI will validate

### Review Focus

Please verify:
- `Order()` behaves identically to `OrderBy(x => x)` for ascending string sort ✅
- `Assert.Equal(Enumerable.Range(1, n), result.Select(h => h.Rank))` is equivalent to the previous `for` loop ✅

---

*Automated by Code Simplifier Agent — analysing C# code from the last 24 hours*

**References:**
- [§22720337928](https://github.com/rowantervelde/agentic-development/actions/runs/22720337928)


<!-- gh-aw-tracker-id: code-simplifier -->




> Generated by [Code Simplifier](https://github.com/rowantervelde/agentic-development/actions/runs/22720337928) · [◷](https://github.com/search?q=repo%3Arowantervelde%2Fagentic-development+is%3Apr+%22gh-aw-workflow-id%3A+code-simplifier%22&type=issues)

> [!WARNING]
> <details>
> <summary>⚠️ Firewall blocked 2 domains</summary>
>
> The following domains were blocked by the firewall during workflow execution:
>
> - `api.nuget.org`
> - `dc.services.visualstudio.com`
>
> To allow these domains, add them to the `network.allowed` list in your workflow frontmatter:
>
> ```yaml
> network:
>   allowed:
>     - defaults
>     - "api.nuget.org"
>     - "dc.services.visualstudio.com"
> ```
>
> See [Network Configuration](https://github.github.com/gh-aw/reference/network/) for more information.
>
> </details>

> - [x] expires <!-- gh-aw-expires: 2026-03-06T13:42:00.158Z --> on Mar 6, 2026, 1:42 PM UTC

<!-- gh-aw-agentic-workflow: Code Simplifier, gh-aw-tracker-id: code-simplifier, engine: copilot, id: 22720337928, workflow_id: code-simplifier, run: https://github.com/rowantervelde/agentic-development/actions/runs/22720337928 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: code-simplifier -->